### PR TITLE
Fix issue with urls ending in ‘/’ getting normalized wrong

### DIFF
--- a/src/SemanticScuttle/Service/Bookmark.php
+++ b/src/SemanticScuttle/Service/Bookmark.php
@@ -1136,7 +1136,7 @@ class SemanticScuttle_Service_Bookmark extends SemanticScuttle_DbService
 
         // Delete final /
         if (substr($address, -1) == '/') {
-            $address = substr($address, 0, strlen($address)-2);
+            $address = substr($address, 0, -1);
         }
 
         return $address;


### PR DESCRIPTION
Hello!

Normalizing them this way ruins the url by cutting off a character too many and making the url invalid.

I ran into this issue where I would bookmark a link like, for example, this one: `https://github.com/buckaroo-labs/SemanticScuttle/` and it would save the link as `https://github.com/buckaroo-labs/SemanticScuttl`, breaking it.

`substr` accepts a negative length argument to cut the address by a certain number of characters rather than to a certain index, so this is equivalent to `substr($address, 0, strlen($address) - 1)`.

Please let me know if something needs to be explained more or changed.

Cheers!